### PR TITLE
Release 20250605

### DIFF
--- a/common/changes/@adobe/ccweb-add-on-sdk-types/release-20250605_2025-06-05-07-29.json
+++ b/common/changes/@adobe/ccweb-add-on-sdk-types/release-20250605_2025-06-05-07-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@adobe/ccweb-add-on-sdk-types",
+      "comment": "Added new exportAllowed iframe API and added properties in pageMetaData to determine whether tha page contains audio/video content and duration of the exported video",
+      "type": "major"
+    }
+  ],
+  "packageName": "@adobe/ccweb-add-on-sdk-types"
+}

--- a/common/changes/@adobe/ccweb-add-on-sdk-types/release-20250605_2025-06-05-07-29.json
+++ b/common/changes/@adobe/ccweb-add-on-sdk-types/release-20250605_2025-06-05-07-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@adobe/ccweb-add-on-sdk-types",
-      "comment": "Added new exportAllowed iframe API and added properties in pageMetaData to determine whether tha page contains audio/video content and duration of the exported video",
+      "comment": "Added new exportAllowed iframe API and documentExportAllowedChange event which is triggered when the document's export permission status changes in review and approval workflow. Also added properties in pageMetaData to determine whether tha page contains audio/video content and duration of the exported video",
       "type": "major"
     }
   ],

--- a/packages/wxp-sdk-types/package.json
+++ b/packages/wxp-sdk-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/ccweb-add-on-sdk-types",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "author": "Adobe",
     "license": "MIT",
     "description": "Type definitions for Adobe Creative Cloud Web Add-on SDK.",

--- a/packages/wxp-sdk-types/ui/ui-sdk.d.ts
+++ b/packages/wxp-sdk-types/ui/ui-sdk.d.ts
@@ -844,12 +844,7 @@ declare interface Document_2 {
      */
     title(): Promise<string>;
     /**
-     * Determines if the document can be exported based on its review status in review and approval workflow.
-     * Returns false if:
-     * - The document requires review but hasn't been approved
-     * - There are pending changes awaiting review.
-     *
-     * @returns Promise<boolean> - True if export is permitted, false otherwise
+     * Returns whether the document can be exported based on its review status in the review and approval workflow.
      */
     exportAllowed(): Promise<boolean>;
     /**

--- a/packages/wxp-sdk-types/ui/ui-sdk.d.ts
+++ b/packages/wxp-sdk-types/ui/ui-sdk.d.ts
@@ -162,7 +162,11 @@ export declare enum AppEvent {
     /**
      * triggered when the document title is changed in the application.
      */
-    documentTitleChange = "documentTitleChange"
+    documentTitleChange = "documentTitleChange",
+    /**
+     * triggered when the document's export permission status changes in review and approval workflow.
+     */
+    documentExportAllowedChange = "documentExportAllowedChange"
 }
 
 export declare type AppEventHandlerType<Event extends AppEventType> = (data: AppEventsTypeMap[Event]) => void;
@@ -182,6 +186,7 @@ declare interface AppEventsTypeMap {
     [AppEvent.documentLinkAvailable]: DocumentLinkAvailableEventData;
     [AppEvent.documentPublishedLinkAvailable]: DocumentPublishedLinkAvailableEventData;
     [AppEvent.documentTitleChange]: DocumentTitleChangeEventData;
+    [AppEvent.documentExportAllowedChange]: DocumentExportAllowedChangeEventData;
 }
 
 export declare type AppEventType = keyof AppEventsTypeMap & string;
@@ -839,6 +844,15 @@ declare interface Document_2 {
      */
     title(): Promise<string>;
     /**
+     * Determines if the document can be exported based on its review status in review and approval workflow.
+     * Returns false if:
+     * - The document requires review but hasn't been approved
+     * - There are pending changes awaiting review.
+     *
+     * @returns Promise<boolean> - True if export is permitted, false otherwise
+     */
+    exportAllowed(): Promise<boolean>;
+    /**
      * Import a Pdf to the document.
      */
     importPdf(blob: Blob, attributes: MediaAttributes & SourceMimeTypeInfo): void;
@@ -853,6 +867,13 @@ declare interface Document_2 {
     runPrintQualityCheck(options: PrintQualityCheckOptions): void;
 }
 export { Document_2 as Document };
+
+/**
+ * The payload data sent when the document's export permission status changes in review and approval workflow.
+ */
+export declare interface DocumentExportAllowedChangeEventData {
+    documentExportAllowed: boolean;
+}
 
 /**
  * The payload data sent to the document id available event handler.
@@ -909,7 +930,7 @@ export declare interface DragCompletionData {
     /**
      * Media info
      */
-    attributes?: MediaAttributes;
+    attributes?: MediaAttributes & SourceMimeTypeInfo;
 }
 
 /**
@@ -1268,6 +1289,22 @@ export declare interface PageMetadata {
      * Whether page contains timelines
      */
     hasTemporalContent: boolean;
+    /**
+     * Duration of the temporal content in seconds. Applicable only if hasTemporalContent is true.
+     */
+    temporalContentDuration?: number;
+    /**
+     * Whether the page contains audio content
+     */
+    hasAudioContent: boolean;
+    /**
+     * Whether the page contains video content
+     */
+    hasVideoContent: boolean;
+    /**
+     * Whether the page contains animated content
+     */
+    hasAnimatedContent: boolean;
     /**
      * Whether the page is blank
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Release the following packages to npmjs:

```
"@adobe/ccweb-add-on-sdk-types": "1.18.0" 
```

## Changes

- Added new exportAllowed iframe API and documentExportAllowedChange event which is triggered when the document's export permission status changes in review and approval workflow.
- Added properties in pageMetaData to determine whether tha page contains audio/video content and duration of the exported video

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
